### PR TITLE
Add `.gitattributes` file for consitent line endings :leftwards_arrow_with_hook:

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.rs text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
+*.fixed linguist-language=Rust


### PR DESCRIPTION
`ui_test` doesn't handle CRLF -> `\n` conversion by default. The `.gitattributes` file somehow fixes this and makes the CI work on all platforms.

See: https://github.com/oli-obk/ui_test/issues/177 for more information