### PR TITLE
Use a new default action command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,14 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  rust-test:
+  cargo-marker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Veetaha/marker@feat/improve-default-action-command
+
+  cargo-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,19 +34,25 @@ jobs:
           install-only: true
       - run: cargo test
 
-  rust-formatting:
+  cargo-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo fmt --check
 
-  rust-lint:
+  cargo-clippy:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo clippy --all-features --all-targets
+
+  cargo-doc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo doc --no-deps
-      - uses: Veetaha/marker@feat/improve-default-action-command

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo doc --no-deps
+      - run: cargo doc --all-features --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,8 @@
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - master
 
 defaults:
   run:
@@ -10,7 +12,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   # Make sure rustc errors on warnings in the CI
-  RUSTFLAGS: "-Dwarnings"
+  RUSTFLAGS: -Dwarnings
 
 jobs:
   rust-test:
@@ -38,10 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: rust-marker/marker@v0.4
-        with:
-          install-only: true
-
       - run: cargo clippy --all-features --all-targets
       - run: cargo doc --no-deps
-      - run: cargo marker -- --all-features --all-targets
+      - uses: Veetaha/marker@feat/improve-default-action-command


### PR DESCRIPTION
The reference to the marker action needs to be updated once the new version with https://github.com/rust-marker/marker/pull/341 is released